### PR TITLE
fix: correct parsing of execution flags

### DIFF
--- a/0/debian-10/rootfs/opt/bitnami/scripts/nginx-ldap-auth-daemon/run.sh
+++ b/0/debian-10/rootfs/opt/bitnami/scripts/nginx-ldap-auth-daemon/run.sh
@@ -16,11 +16,11 @@ eval "$(nginxldap_env)"
 
 flags=("--host" "${NGINXLDAP_HOSTNAME}" "-p" "${NGINXLDAP_PORT_NUMBER}" "--url" "${NGINXLDAP_LDAP_URI}")
 [[ -n "${NGINXLDAP_LDAP_BASE_DN}" ]] && flags=("${flags[@]}" "-b" "${NGINXLDAP_LDAP_BASE_DN}")
-[[ -n "${NGINXLDAP_LDAP_BIND_DN}" ]] && flags=("${flags[@]}" "-D ${NGINXLDAP_LDAP_BIND_DN}")
-[[ -n "${NGINXLDAP_LDAP_BIND_PASSWORD}" ]] && flags=("${flags[@]}" "-w ${NGINXLDAP_LDAP_BIND_PASSWORD}")
-[[ -n "${NGINXLDAP_LDAP_FILTER}" ]] && flags=("${flags[@]}" "-f ${NGINXLDAP_LDAP_FILTER}")
-[[ -n "${NGINXLDAP_HTTP_REALM}" ]] && flags=("${flags[@]}" "-R ${NGINXLDAP_HTTP_REALM}")
-[[ -n "${NGINXLDAP_HTTP_COOKIE_NAME}" ]] && flags=("${flags[@]}" "-c ${NGINXLDAP_HTTP_COOKIE_NAME}")
+[[ -n "${NGINXLDAP_LDAP_BIND_DN}" ]] && flags=("${flags[@]}" "-D" "${NGINXLDAP_LDAP_BIND_DN}")
+[[ -n "${NGINXLDAP_LDAP_BIND_PASSWORD}" ]] && flags=("${flags[@]}" "-w" "${NGINXLDAP_LDAP_BIND_PASSWORD}")
+[[ -n "${NGINXLDAP_LDAP_FILTER}" ]] && flags=("${flags[@]}" "-f" "${NGINXLDAP_LDAP_FILTER}")
+[[ -n "${NGINXLDAP_HTTP_REALM}" ]] && flags=("${flags[@]}" "-R" "${NGINXLDAP_HTTP_REALM}")
+[[ -n "${NGINXLDAP_HTTP_COOKIE_NAME}" ]] && flags=("${flags[@]}" "-c" "${NGINXLDAP_HTTP_COOKIE_NAME}")
 
 info "** Starting NGINX LDAP Auth daemong **"
 # shellcheck source=/dev/null


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
By making flags and their corresponding values independent items in the `flags` array, the main python file does correctly parse them and configuration is set properly.

**Benefits**

Users are now able to correctly configure the daemon using environment variables only, as stated in the README.

**Possible drawbacks**

None

**Applicable issues**

#3 

**Additional information**

Changes have been tested by performing a request to http://localhost:8080 and introducing correct credentials. This time, access is granted and the resource is displayed:

![Screenshot 2020-12-21 at 21 50 40](https://user-images.githubusercontent.com/24253844/102924909-bb1bb000-4492-11eb-9305-ed9c27d1c6d9.png)

Additionally, `OpenLDAP` logs display now a successful request:

```bash
nginx_1       | 172.21.0.1 - - [21/Dec/2020:20:51:17 +0000] "GET / HTTP/1.1" 401 172 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:84.0) Gecko/20100101 Firefox/84.0"
openldap_1    | 5fe10acf conn=1000 fd=15 ACCEPT from IP=172.21.0.3:35282 (IP=0.0.0.0:1389)
openldap_1    | 5fe10acf conn=1000 op=0 BIND dn="cn=admin,dc=example,dc=org" method=128
openldap_1    | 5fe10acf conn=1000 op=0 BIND dn="cn=admin,dc=example,dc=org" mech=SIMPLE ssf=0
openldap_1    | 5fe10acf conn=1000 op=0 RESULT tag=97 err=0 text=
openldap_1    | 5fe10acf conn=1000 op=1 SRCH base="dc=example,dc=org" scope=2 deref=0 filter="(cn=user01)"
openldap_1    | 5fe10acf conn=1000 op=1 SRCH attr=objectclass
openldap_1    | 5fe10acf conn=1000 op=1 SEARCH RESULT tag=101 err=0 nentries=1 text=
openldap_1    | 5fe10acf conn=1000 op=2 BIND anonymous mech=implicit ssf=0
openldap_1    | 5fe10acf conn=1000 op=2 BIND dn="cn=user01,ou=users,dc=example,dc=org" method=128
openldap_1    | 5fe10acf conn=1000 op=2 BIND dn="cn=user01,ou=users,dc=example,dc=org" mech=SIMPLE ssf=0
openldap_1    | 5fe10acf conn=1000 op=2 RESULT tag=97 err=0 text=
openldap_1    | 5fe10acf conn=1000 op=3 UNBIND
openldap_1    | 5fe10acf conn=1000 fd=15 closed
```
